### PR TITLE
Fix github pre-commit action using incomplete python env

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,4 +1,4 @@
-name: Run pre-commit in blueprint
+name: Run pre-commit job
 
 on:
  push:
@@ -9,7 +9,7 @@ on:
     - main
 
 jobs:
- blueprint-pre-commit:
+ pre-commit-job:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -19,10 +19,15 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.11.7
+        python-version: 3.9
     - name: Install pre-commit hooks
       run: |
+        pip install torch==2.0.1 torchvision==0.15.2 torchaudio==2.0.2 \
+          --index-url https://download.pytorch.org/whl/cpu
         pip install -r requirements.txt
+        pip install pyg-lib==0.2.0 torch-scatter==2.1.1 torch-sparse==0.6.17 \
+          torch-cluster==1.6.1 torch-geometric==2.3.1 \
+          -f https://pytorch-geometric.com/whl/torch-2.0.1+cpu.html
     - name: Run pre-commit hooks
       run: |
         pre-commit run --all-files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,3 +61,5 @@ disable = [
 max-statements=100 # Allow for some more involved functions
 [tool.pylint.IMPORTS]
 allow-any-import-level="neural_lam"
+[tool.pylint.SIMILARITIES]
+min-similarity-lines=10


### PR DESCRIPTION
The initial run of the pre-commit job seems to have failed (https://github.com/joeloskarsson/neural-lam/commit/474bad970458375ecd7c50e0a1c11b976d0c1fbf). Looks like the python environment did not have pytorch geometric as it was only installingfrom `requirements.txt`. I here try to mirror the python installation instructions from `README .md` in the github action setup.