### PR TITLE
Remove batch-static tensor from dataset class and models

### DIFF
--- a/create_parameter_weights.py
+++ b/create_parameter_weights.py
@@ -82,7 +82,7 @@ def main():
     squares = []
     flux_means = []
     flux_squares = []
-    for init_batch, target_batch, _, forcing_batch in tqdm(loader):
+    for init_batch, target_batch, forcing_batch in tqdm(loader):
         batch = torch.cat(
             (init_batch, target_batch), dim=1
         )  # (N_batch, N_t, N_grid, d_features)
@@ -91,7 +91,8 @@ def main():
             torch.mean(batch**2, dim=(1, 2))
         )  # (N_batch, d_features,)
 
-        flux_batch = forcing_batch[:, :, :, 0]  # Flux is first index
+        # Flux at 1st windowed position is index 1 in forcing
+        flux_batch = forcing_batch[:, :, :, 1]
         flux_means.append(torch.mean(flux_batch))  # (,)
         flux_squares.append(torch.mean(flux_batch**2))  # (,)
 
@@ -125,7 +126,7 @@ def main():
 
     diff_means = []
     diff_squares = []
-    for init_batch, target_batch, _, _ in tqdm(loader_standard):
+    for init_batch, target_batch, _ in tqdm(loader_standard):
         batch = torch.cat(
             (init_batch, target_batch), dim=1
         )  # (N_batch, N_t', N_grid, d_features)

--- a/neural_lam/constants.py
+++ b/neural_lam/constants.py
@@ -116,5 +116,5 @@ LAMBERT_PROJ = cartopy.crs.LambertConformal(
 )
 
 # Data dimensions
-GRID_FORCING_DIM = 5 * 3 + 1 # 5 feat. for 3 time-step window + 1 batch-static
+GRID_FORCING_DIM = 5 * 3 + 1  # 5 feat. for 3 time-step window + 1 batch-static
 GRID_STATE_DIM = 17

--- a/neural_lam/constants.py
+++ b/neural_lam/constants.py
@@ -116,6 +116,5 @@ LAMBERT_PROJ = cartopy.crs.LambertConformal(
 )
 
 # Data dimensions
-BATCH_STATIC_FEATURE_DIM = 1  # Only open water
-GRID_FORCING_DIM = 5 * 3  # 5 features for 3 time-step window
+GRID_FORCING_DIM = 5 * 3 + 1 # 5 feat. for 3 time-step window + 1 batch-static
 GRID_STATE_DIM = 17

--- a/neural_lam/models/ar_model.py
+++ b/neural_lam/models/ar_model.py
@@ -116,9 +116,7 @@ class ARModel(pl.LightningModule):
         """
         return x.unsqueeze(0).expand(batch_size, -1, -1)
 
-    def predict_step(
-        self, prev_state, prev_prev_state, forcing
-    ):
+    def predict_step(self, prev_state, prev_prev_state, forcing):
         """
         Step state one step ahead using prediction model, X_{t-1}, X_t -> X_t+1
         prev_state: (B, num_grid_nodes, feature_dim), X_t
@@ -127,9 +125,7 @@ class ARModel(pl.LightningModule):
         """
         raise NotImplementedError("No prediction step implemented")
 
-    def unroll_prediction(
-        self, init_states, forcing_features, true_states
-    ):
+    def unroll_prediction(self, init_states, forcing_features, true_states):
         """
         Roll out prediction taking multiple autoregressive steps with model
         init_states: (B, 2, num_grid_nodes, d_f)

--- a/neural_lam/models/base_graph_model.py
+++ b/neural_lam/models/base_graph_model.py
@@ -98,9 +98,7 @@ class BaseGraphModel(ARModel):
         """
         raise NotImplementedError("process_step not implemented")
 
-    def predict_step(
-        self, prev_state, prev_prev_state, forcing
-    ):
+    def predict_step(self, prev_state, prev_prev_state, forcing):
         """
         Step state one step ahead using prediction model, X_{t-1}, X_t -> X_t+1
         prev_state: (B, num_grid_nodes, feature_dim), X_t

--- a/neural_lam/models/base_graph_model.py
+++ b/neural_lam/models/base_graph_model.py
@@ -34,7 +34,7 @@ class BaseGraphModel(ARModel):
             f"nodes ({self.num_grid_nodes} grid, {self.num_mesh_nodes} mesh)"
         )
 
-        # grid_dim from data + static + batch_static
+        # grid_dim from data + static
         self.g2m_edges, g2m_dim = self.g2m_features.shape
         self.m2g_edges, m2g_dim = self.m2g_features.shape
 
@@ -99,13 +99,12 @@ class BaseGraphModel(ARModel):
         raise NotImplementedError("process_step not implemented")
 
     def predict_step(
-        self, prev_state, prev_prev_state, batch_static_features, forcing
+        self, prev_state, prev_prev_state, forcing
     ):
         """
         Step state one step ahead using prediction model, X_{t-1}, X_t -> X_t+1
         prev_state: (B, num_grid_nodes, feature_dim), X_t
         prev_prev_state: (B, num_grid_nodes, feature_dim), X_{t-1}
-        batch_static_features: (B, num_grid_nodes, batch_static_feature_dim)
         forcing: (B, num_grid_nodes, forcing_dim)
         """
         batch_size = prev_state.shape[0]
@@ -115,7 +114,6 @@ class BaseGraphModel(ARModel):
             (
                 prev_state,
                 prev_prev_state,
-                batch_static_features,
                 forcing,
                 self.expand_to_batch(self.grid_static_features, batch_size),
             ),

--- a/neural_lam/weather_dataset.py
+++ b/neural_lam/weather_dataset.py
@@ -156,22 +156,29 @@ class WeatherDataset(torch.utils.data.Dataset):
         init_states = sample[:2]  # (2, N_grid, d_features)
         target_states = sample[2:]  # (sample_length-2, N_grid, d_features)
 
-        # === Static batch features ===
+        # === Forcing features ===
+        # Now batch-static features are just part of forcing,
+        # repeated over temporal dimension
         # Load water coverage
         sample_datetime = sample_name[:10]
         water_path = os.path.join(
             self.sample_dir_path, f"wtr_{sample_datetime}.npy"
         )
-        static_features = torch.tensor(
+        water_cover_features = torch.tensor(
             np.load(water_path), dtype=torch.float32
         ).unsqueeze(
             -1
         )  # (dim_x, dim_y, 1)
         # Flatten
-        static_features = static_features.flatten(0, 1)  # (N_grid, 1)
+        water_cover_features = water_cover_features.flatten(0, 1)  # (N_grid, 1)
+        # Exand over temporal dimension
+        water_cover_expanded = water_cover_features.unsqueeze(0).expand(
+            self.sample_length - 2,  # -2 as added on after windowing
+            -1,
+            -1
+        )  # (sample_len, N_grid, 1)
 
-        # === Forcing features ===
-        # Forcing features
+        # TOA flux
         flux_path = os.path.join(
             self.sample_dir_path,
             f"nwp_toa_downwelling_shortwave_flux_{sample_datetime}.npy",
@@ -247,4 +254,9 @@ class WeatherDataset(torch.utils.data.Dataset):
         )  # (sample_len-2, N_grid, 3*d_forcing)
         # Now index 0 of ^ corresponds to forcing at index 0-2 of sample
 
-        return init_states, target_states, static_features, forcing_windowed
+        # batch-static water cover is added after windowing,
+        # as it is static over time
+        forcing = torch.cat((water_cover_expanded, forcing_windowed), dim=2)
+        # (sample_len-2, N_grid, forcing_dim)
+
+        return init_states, target_states, forcing

--- a/neural_lam/weather_dataset.py
+++ b/neural_lam/weather_dataset.py
@@ -171,11 +171,9 @@ class WeatherDataset(torch.utils.data.Dataset):
         )  # (dim_x, dim_y, 1)
         # Flatten
         water_cover_features = water_cover_features.flatten(0, 1)  # (N_grid, 1)
-        # Exand over temporal dimension
+        # Expand over temporal dimension
         water_cover_expanded = water_cover_features.unsqueeze(0).expand(
-            self.sample_length - 2,  # -2 as added on after windowing
-            -1,
-            -1
+            self.sample_length - 2, -1, -1  # -2 as added on after windowing
         )  # (sample_len, N_grid, 1)
 
         # TOA flux


### PR DESCRIPTION
The batch-static tensor contained forcing that differed between initialization times, but stayed static for all lead times of a forecast. For the MEPS data we used this for the land-water-mask, as this could be different throughout the year, but we could not produce separate values per lead time (as all other forcing).

This PR removes the batch-static features as an explicit extra input. The motivation is:

1. Having such input features is quite a rare and a highly specific case.
2. If such inputs exists, it is better to just treat them as any other type of forcing. Then the values have to be repeated over the temporal dimension, but this can either be handled in pre-processing or easily in the Dataset class. In this PR the MEPS Dataset class is changed to take this approach.
3. Needing to pass around the batch-static features clutter up the code. For most dataset they would not be used, requiring constant special checks for if they are `None`.

This PR changes:

1. Bake the batch-static features into the normal forcing in the MEPS Dataset class.
2. Change the Dataset class to only return 3 tensors per sample (init, target, forcing).
3. Remove the batch-static tensor from being extracted from the batch and passed around in the graph-based models. This while making sure that input dimensions line up so older checkpoints can still be loaded correctly. 